### PR TITLE
Book fulltext fix

### DIFF
--- a/Phaidra/src/main/java/it/imtech/upload/ImObject.java
+++ b/Phaidra/src/main/java/it/imtech/upload/ImObject.java
@@ -517,11 +517,12 @@ public class ImObject {
                 if (words.item(s).getNodeType() == Node.ELEMENT_NODE) {
                     Element word = (Element) words.item(s);
 
-                    thisPage.addToFulltext(word.getAttribute("word"));
-
-                    this.bookFulltext.addText(thisPage.getFulltext());
-                }
+                    thisPage.addToFulltext(word.getAttribute("word"));                    
+                }                
             }
+            
+            this.bookFulltext.addText(thisPage.getFulltext());
+            
         } catch (Exception ex) {
             throw new Exception("OCR Upload Exception: " + ex.getMessage());
         }


### PR DESCRIPTION
Phaidra-importer was creating huge book fulltext because it was appending all page fulltext for every word found in page OCR